### PR TITLE
Extract version from module itself.

### DIFF
--- a/jambel.py
+++ b/jambel.py
@@ -17,6 +17,7 @@ import logging
 import telnetlib
 import re
 
+__version__ = '0.1.1'
 
 OFF = 0
 ON = 1

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,21 @@
 from setuptools import setup
 import os
+import re
 
+def get_version():
+	"""
+	Extracts version directly from Jambel module.
+	"""
+	version_reg = re.compile("""^__version__ = '(.*)'""", re.M)
+	_here = os.path.dirname(os.path.abspath(__file__))
+	path = os.path.join(_here, 'jambel.py')	
+	m = version_reg.search(open(path).read())
+	return m.group(1) if m is not None else '?'
+	
+	
 setup(
     name='jambel',
-    version='0.1.1',
+    version=get_version(),
     py_modules=['jambel'],
     url='http://github.com/jambit/python-jambel',
     license='MIT',


### PR DESCRIPTION
Maintaining the version in the module itself is easier in the long run. Plus anyone using the module locally (without installing it in site-packages) will know the version as well.